### PR TITLE
Umbrella app's test directories were generated with type `src` instead of `test`

### DIFF
--- a/lib/ex_projections/gen_data.ex
+++ b/lib/ex_projections/gen_data.ex
@@ -35,7 +35,7 @@ defmodule ExProjections.GenData do
   defp test_map(dir) do
     %{
       "apps/#{dir}/test/*_test.exs" => %{
-        "type" => "src",
+        "type" => "test",
         "alternate" => "apps/#{dir}/lib/{}.ex"
       }
     }


### PR DESCRIPTION
If you run `mix ex_projections` in an umbrella app with two apps for instance, it will generate an output similar to the following:

```javascript
{
  "apps/first/lib/*.ex": {
    "alternate": "apps/first/test/{}_test.exs",
    "type": "src"
  },
  "apps/first/test/*_test.exs": {
    "alternate": "apps/first/lib/{}.ex",
    "type": "src"
  },
  "apps/second/lib/*.ex": {
    "alternate": "apps/second/test/{}_test.exs",
    "type": "src"
  },
  "apps/second/test/*_test.exs": {
    "alternate": "apps/second/lib/{}.ex",
    "type": "src"
  }
}
```
The expected output would be:
```javascript
{
  "apps/first/lib/*.ex": {
    "alternate": "apps/first/test/{}_test.exs",
    "type": "src"
  },
  "apps/first/test/*_test.exs": {
    "alternate": "apps/first/lib/{}.ex",
    "type": "test"
  },
  "apps/second/lib/*.ex": {
    "alternate": "apps/second/test/{}_test.exs",
    "type": "src"
  },
  "apps/second/test/*_test.exs": {
    "alternate": "apps/second/lib/{}.ex",
    "type": "test"
  }
}
```